### PR TITLE
docs: fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ For guidance on how to exclude more files, see my
 ## Branding Notice
 
 For branding assets to be used in marketing materials head over to the
-[`sablier-labs/branding`](github.com/sablier-labs/branding) repository.
+[`sablier-labs/branding`](https://github.com/sablier-labs/branding) repository.


### PR DESCRIPTION
Closes https://github.com/sablier-labs/sablier-labs.github.io/issues/4.

a broken link in the documentation has been replaced, I want to thank the developer https://github.com/smol-ninja for his help