### PR TITLE
 feat: sort source token files in sort-tokens script

### DIFF
--- a/scripts/token-list/sort-tokens.ts
+++ b/scripts/token-list/sort-tokens.ts
@@ -1,27 +1,21 @@
 import { join } from "node:path";
 import { NodeRuntime } from "@effect/platform-node";
 import type { TokenInfo, TokenList } from "@uniswap/token-lists";
-import { Console, Effect } from "effect";
+import { Array as Arr, Console, Effect, Order } from "effect";
 import { TokenFileSystem } from "./services/TokenFileSystem.js";
 import type { SolanaToken } from "./types.js";
 
 const TOKENS_DIR = "token-list";
 
-const sortEvmTokens = (tokens: TokenInfo[]): TokenInfo[] =>
-  tokens.sort((a, b) => {
-    if (a.chainId === b.chainId) {
-      return a.symbol.toLowerCase().localeCompare(b.symbol.toLowerCase());
-    }
-    return a.chainId < b.chainId ? -1 : 1;
-  });
+const EvmTokenOrder = Order.combineAll<TokenInfo>([
+  Order.mapInput(Order.number, (t) => t.chainId),
+  Order.mapInput(Order.string, (t) => t.symbol.toLowerCase()),
+]);
 
-const sortSolanaTokens = (tokens: SolanaToken[]): SolanaToken[] =>
-  tokens.sort((a, b) => {
-    if (a.cluster === b.cluster) {
-      return a.symbol.toLowerCase().localeCompare(b.symbol.toLowerCase());
-    }
-    return a.cluster.localeCompare(b.cluster);
-  });
+const SolanaTokenOrder = Order.combineAll<SolanaToken>([
+  Order.mapInput(Order.string, (t) => t.cluster),
+  Order.mapInput(Order.string, (t) => t.symbol.toLowerCase()),
+]);
 
 /** Sort generated token list files (evm.json, solana.json) */
 const sortGeneratedFile = (filePath: string, isSolana: boolean) =>
@@ -30,8 +24,8 @@ const sortGeneratedFile = (filePath: string, isSolana: boolean) =>
     const tokenList = yield* fs.readJsonFile<TokenList>(filePath);
 
     const sortedTokens = isSolana
-      ? sortSolanaTokens(tokenList.tokens as SolanaToken[])
-      : sortEvmTokens(tokenList.tokens);
+      ? Arr.sort(tokenList.tokens as SolanaToken[], SolanaTokenOrder)
+      : Arr.sort(tokenList.tokens, EvmTokenOrder);
 
     const updatedList = { ...tokenList, tokens: sortedTokens };
     const jsonContent = JSON.stringify(updatedList, null, 2) + "\n";
@@ -47,8 +41,8 @@ const sortSourceFile = (filePath: string, isSolana: boolean) =>
     const tokens = yield* fs.readJsonFile<TokenInfo[] | SolanaToken[]>(filePath);
 
     const sortedTokens = isSolana
-      ? sortSolanaTokens(tokens as SolanaToken[])
-      : sortEvmTokens(tokens as TokenInfo[]);
+      ? Arr.sort(tokens as SolanaToken[], SolanaTokenOrder)
+      : Arr.sort(tokens as TokenInfo[], EvmTokenOrder);
 
     const jsonContent = JSON.stringify(sortedTokens, null, 2) + "\n";
     yield* fs.writeFile(filePath, jsonContent);
@@ -58,35 +52,41 @@ const sortSourceFile = (filePath: string, isSolana: boolean) =>
 
 const program = Effect.gen(function* () {
   const fs = yield* TokenFileSystem;
-  let totalFiles = 0;
 
   // Sort source files in evm/ and solana/ directories
-  for (const subdir of ["evm", "solana"]) {
-    const dirPath = join(TOKENS_DIR, subdir);
-    const files = yield* fs.readDirectory(dirPath);
-    const jsonFiles = files.filter((f) => f.endsWith(".json"));
-    const isSolana = subdir === "solana";
+  const sourceCounts = yield* Effect.forEach(["evm", "solana"] as const, (subdir) =>
+    Effect.gen(function* () {
+      const dirPath = join(TOKENS_DIR, subdir);
+      const files = yield* fs.readDirectory(dirPath);
+      const jsonFiles = files.filter((f) => f.endsWith(".json"));
+      const isSolana = subdir === "solana";
 
-    for (const file of jsonFiles) {
-      const filePath = join(dirPath, file);
-      const count = yield* sortSourceFile(filePath, isSolana);
-      yield* Console.log(`✓ Sorted ${count} tokens in ${subdir}/${file}`);
-      totalFiles++;
-    }
-  }
+      yield* Effect.forEach(jsonFiles, (file) =>
+        Effect.gen(function* () {
+          const filePath = join(dirPath, file);
+          const count = yield* sortSourceFile(filePath, isSolana);
+          yield* Console.log(`✓ Sorted ${count} tokens in ${subdir}/${file}`);
+        }),
+      );
+
+      return jsonFiles.length;
+    }),
+  );
 
   // Sort generated files in token-list/
   const files = yield* fs.readDirectory(TOKENS_DIR);
   const jsonFiles = files.filter((f) => f.endsWith(".json"));
 
-  for (const file of jsonFiles) {
-    const filePath = join(TOKENS_DIR, file);
-    const isSolana = file.includes("solana");
-    const count = yield* sortGeneratedFile(filePath, isSolana);
-    yield* Console.log(`✓ Sorted ${count} tokens in ${file}`);
-    totalFiles++;
-  }
+  yield* Effect.forEach(jsonFiles, (file) =>
+    Effect.gen(function* () {
+      const filePath = join(TOKENS_DIR, file);
+      const isSolana = file.includes("solana");
+      const count = yield* sortGeneratedFile(filePath, isSolana);
+      yield* Console.log(`✓ Sorted ${count} tokens in ${file}`);
+    }),
+  );
 
+  const totalFiles = Arr.reduce(sourceCounts, 0, (acc, n) => acc + n) + jsonFiles.length;
   yield* Console.log(`\n✓ All ${totalFiles} files sorted successfully`);
 }).pipe(Effect.provide(TokenFileSystem.Default));
 

--- a/token-list/evm/1.json
+++ b/token-list/evm/1.json
@@ -248,6 +248,14 @@
     "symbol": "BZRX"
   },
   {
+    "address": "0xBe9895146f7AF43049ca1c1AE358B0541Ea49704",
+    "chainId": 1,
+    "decimals": 18,
+    "logoURI": "https://ethereum-optimism.github.io/data/cbETH/logo.svg",
+    "name": "Coinbase Wrapped Staked ETH",
+    "symbol": "cbETH"
+  },
+  {
     "address": "0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643",
     "chainId": 1,
     "decimals": 8,
@@ -302,14 +310,6 @@
     "logoURI": "https://files.sablier.com/tokens/COMBO.png",
     "name": "Furucombo",
     "symbol": "COMBO"
-  },
-  {
-    "address": "0xBe9895146f7AF43049ca1c1AE358B0541Ea49704",
-    "chainId": 1,
-    "decimals": 18,
-    "logoURI": "https://ethereum-optimism.github.io/data/cbETH/logo.svg",
-    "name": "Coinbase Wrapped Staked ETH",
-    "symbol": "cbETH"
   },
   {
     "address": "0xc00e94Cb662C3520282E6f5717214004A7f26888",
@@ -526,6 +526,14 @@
     "logoURI": "https://files.sablier.com/tokens/DYAD.png",
     "name": "DYAD Stable",
     "symbol": "DYAD"
+  },
+  {
+    "address": "0x474eD38C256A7FA0f3B8c48496CE1102ab0eA91E",
+    "chainId": 1,
+    "decimals": 18,
+    "logoURI": "https://files.sablier.com/tokens/EAGLE.png",
+    "name": "Eagle",
+    "symbol": "EAGLE"
   },
   {
     "address": "0x974D796E0Bea47038f39C3F98b1aA2c5240b5495",
@@ -1464,6 +1472,14 @@
     "symbol": "PAPER"
   },
   {
+    "address": "0x38778E6d4d0dbE9bEceF3aE8B938570209efa48B",
+    "chainId": 1,
+    "decimals": 18,
+    "logoURI": "https://files.sablier.com/tokens/PAST.png",
+    "name": "Punk Auction Strategy Token",
+    "symbol": "PAST"
+  },
+  {
     "address": "0x60bE1e1fE41c1370ADaF5d8e66f07Cf1C2Df2268",
     "chainId": 1,
     "decimals": 18,
@@ -1688,6 +1704,14 @@
     "symbol": "RFKJ"
   },
   {
+    "address": "0xdA7AD9dea9397cffdDAE2F8a052B82f1484252B3",
+    "chainId": 1,
+    "decimals": 18,
+    "logoURI": "https://files.sablier.com/tokens/RIVER.png",
+    "name": "River",
+    "symbol": "RIVER"
+  },
+  {
     "address": "0x60e254E35Dd712394b3AbA7A1D19114732e143dD",
     "chainId": 1,
     "decimals": 18,
@@ -1750,14 +1774,6 @@
     "logoURI": "https://files.sablier.com/tokens/RVST.png",
     "name": "Revest",
     "symbol": "RVST"
-  },
-  {
-    "address": "0xdA7AD9dea9397cffdDAE2F8a052B82f1484252B3",
-    "chainId": 1,
-    "decimals": 18,
-    "logoURI": "https://files.sablier.com/tokens/RIVER.png",
-    "name": "River",
-    "symbol": "RIVER"
   },
   {
     "address": "0x44e3ae622c1570Dc6E492aDB8DE92d01cA923d26",
@@ -1854,6 +1870,14 @@
     "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xEd0439EACf4c4965AE4613D77a5C2Efe10e5f183/logo.png",
     "name": "Shroom.Finance",
     "symbol": "SHROOM"
+  },
+  {
+    "address": "0xe485E2f1bab389C08721B291f6b59780feC83Fd7",
+    "chainId": 1,
+    "decimals": 18,
+    "logoURI": "https://files.sablier.com/tokens/SHU.png",
+    "name": "Shutter Token",
+    "symbol": "SHU"
   },
   {
     "address": "0xDb82c0d91E057E05600C8F8dc836bEb41da6df14",
@@ -2534,29 +2558,5 @@
     "logoURI": "https://files.sablier.com/tokens/ZRS.png",
     "name": "Zaros Finance",
     "symbol": "ZRS"
-  },
-  {
-    "address": "0x38778E6d4d0dbE9bEceF3aE8B938570209efa48B",
-    "chainId": 1,
-    "decimals": 18,
-    "logoURI": "https://files.sablier.com/tokens/PAST.png",
-    "name": "Punk Auction Strategy Token",
-    "symbol": "PAST"
-  },
-  {
-    "address": "0x474eD38C256A7FA0f3B8c48496CE1102ab0eA91E",
-    "chainId": 1,
-    "decimals": 18,
-    "logoURI": "https://files.sablier.com/tokens/EAGLE.png",
-    "name": "Eagle",
-    "symbol": "EAGLE"
-  },
-  {
-    "address": "0xe485E2f1bab389C08721B291f6b59780feC83Fd7",
-    "chainId": 1,
-    "decimals": 18,
-    "logoURI": "https://files.sablier.com/tokens/SHU.png",
-    "name": "Shutter Token",
-    "symbol": "SHU"
   }
 ]

--- a/token-list/evm/1.json
+++ b/token-list/evm/1.json
@@ -1,13 +1,5 @@
 [
   {
-    "address": "0x00000000000007C8612bA63Df8DdEfD9E6077c97",
-    "chainId": 1,
-    "decimals": 18,
-    "logoURI": "https://files.sablier.com/tokens/NANI.png",
-    "name": "NANI",
-    "symbol": "⌘"
-  },
-  {
     "address": "0xB6eD7644C69416d67B522e20bC294A9a9B405B31",
     "chainId": 1,
     "decimals": 8,
@@ -2558,5 +2550,13 @@
     "logoURI": "https://files.sablier.com/tokens/ZRS.png",
     "name": "Zaros Finance",
     "symbol": "ZRS"
+  },
+  {
+    "address": "0x00000000000007C8612bA63Df8DdEfD9E6077c97",
+    "chainId": 1,
+    "decimals": 18,
+    "logoURI": "https://files.sablier.com/tokens/NANI.png",
+    "name": "NANI",
+    "symbol": "⌘"
   }
 ]

--- a/token-list/evm/143.json
+++ b/token-list/evm/143.json
@@ -1,21 +1,5 @@
 [
   {
-    "address": "0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A",
-    "chainId": 143,
-    "decimals": 18,
-    "logoURI": "https://files.sablier.com/tokens/MON.png",
-    "name": "Wrapped MON",
-    "symbol": "WMON"
-  },
-  {
-    "address": "0xEE8c0E9f1BFFb4Eb878d8f15f368A02a35481242",
-    "chainId": 143,
-    "decimals": 18,
-    "logoURI": "https://files.sablier.com/tokens/WETH.png",
-    "name": "Wrapped Ether",
-    "symbol": "WETH"
-  },
-  {
     "address": "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",
     "chainId": 143,
     "decimals": 6,
@@ -30,5 +14,21 @@
     "logoURI": "https://files.sablier.com/tokens/USDT.png",
     "name": "USDT0",
     "symbol": "USDT0"
+  },
+  {
+    "address": "0xEE8c0E9f1BFFb4Eb878d8f15f368A02a35481242",
+    "chainId": 143,
+    "decimals": 18,
+    "logoURI": "https://files.sablier.com/tokens/WETH.png",
+    "name": "Wrapped Ether",
+    "symbol": "WETH"
+  },
+  {
+    "address": "0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A",
+    "chainId": 143,
+    "decimals": 18,
+    "logoURI": "https://files.sablier.com/tokens/MON.png",
+    "name": "Wrapped MON",
+    "symbol": "WMON"
   }
 ]

--- a/token-list/evm/8453.json
+++ b/token-list/evm/8453.json
@@ -104,6 +104,14 @@
     "symbol": "ATA"
   },
   {
+    "address": "0x9d56c29e820Dd13b0580B185d0e0Dc301d27581d",
+    "chainId": 8453,
+    "decimals": 18,
+    "logoURI": "https://files.sablier.com/tokens/AUBRAI.png",
+    "name": "Aubrai by Bio",
+    "symbol": "AUBRAI"
+  },
+  {
     "address": "0x80f6bcedd3d4fa1035285affa30e38f464db3895",
     "chainId": 8453,
     "decimals": 18,
@@ -168,6 +176,14 @@
     "symbol": "cbETH"
   },
   {
+    "address": "0xcb17C9Db87B595717C857a08468793f5bAb6445F",
+    "chainId": 8453,
+    "decimals": 8,
+    "logoURI": "https://files.sablier.com/tokens/cbLTC.png",
+    "name": "Coinbase Wrapped LTC",
+    "symbol": "cbLTC"
+  },
+  {
     "address": "0xD2237D9fE0c36721220e4bD88aa85b55ffDA0E84",
     "chainId": 8453,
     "decimals": 8,
@@ -206,6 +222,30 @@
     "logoURI": "https://files.sablier.com/tokens/DPHN.png",
     "name": "Dolphin",
     "symbol": "DPHN"
+  },
+  {
+    "address": "0x29cC30f9D113B356Ce408667aa6433589CeCBDcA",
+    "chainId": 8453,
+    "decimals": 18,
+    "logoURI": "https://files.sablier.com/tokens/ELSA.png",
+    "name": "Elsa",
+    "symbol": "ELSA"
+  },
+  {
+    "address": "0xc7c154A93127ad933844FE21b20358397edC0e8C",
+    "chainId": 8453,
+    "decimals": 18,
+    "logoURI": "https://files.sablier.com/tokens/EMMA.png",
+    "name": "Dr Emma Sage by Virtuals",
+    "symbol": "EMMA"
+  },
+  {
+    "address": "0xC44141a684f6AA4E36cD9264ab55550B03C88643",
+    "chainId": 8453,
+    "decimals": 18,
+    "logoURI": "https://files.sablier.com/tokens/ETHY.png",
+    "name": "Ethy AI by Virtuals",
+    "symbol": "ETHY"
   },
   {
     "address": "0x9A86980D3625b4A6E69D8a4606D51cbc019e2002",
@@ -294,6 +334,14 @@
     "logoURI": "https://files.sablier.com/tokens/KAITO.png",
     "name": "KAITO",
     "symbol": "KAITO"
+  },
+  {
+    "address": "0x9EadbE35F3Ee3bF3e28180070C429298a1b02F93",
+    "chainId": 8453,
+    "decimals": 18,
+    "logoURI": "https://files.sablier.com/tokens/LMTS.png",
+    "name": "Limitless",
+    "symbol": "LMTS"
   },
   {
     "address": "0xFD55f09328d7DcCc1C596dc981496546250d8804",
@@ -550,53 +598,5 @@
     "logoURI": "https://files.sablier.com/tokens/ZEN.png",
     "name": "Horizen",
     "symbol": "ZEN"
-  },
-  {
-    "address": "0xC44141a684f6AA4E36cD9264ab55550B03C88643",
-    "chainId": 8453,
-    "decimals": 18,
-    "logoURI": "https://files.sablier.com/tokens/ETHY.png",
-    "name": "Ethy AI by Virtuals",
-    "symbol": "ETHY"
-  },
-  {
-    "address": "0xc7c154A93127ad933844FE21b20358397edC0e8C",
-    "chainId": 8453,
-    "decimals": 18,
-    "logoURI": "https://files.sablier.com/tokens/EMMA.png",
-    "name": "Dr Emma Sage by Virtuals",
-    "symbol": "EMMA"
-  },
-  {
-    "address": "0x9d56c29e820Dd13b0580B185d0e0Dc301d27581d",
-    "chainId": 8453,
-    "decimals": 18,
-    "logoURI": "https://files.sablier.com/tokens/AUBRAI.png",
-    "name": "Aubrai by Bio",
-    "symbol": "AUBRAI"
-  },
-  {
-    "address": "0x9EadbE35F3Ee3bF3e28180070C429298a1b02F93",
-    "chainId": 8453,
-    "decimals": 18,
-    "logoURI": "https://files.sablier.com/tokens/LMTS.png",
-    "name": "Limitless",
-    "symbol": "LMTS"
-  },
-  {
-    "address": "0xcb17C9Db87B595717C857a08468793f5bAb6445F",
-    "chainId": 8453,
-    "decimals": 8,
-    "logoURI": "https://files.sablier.com/tokens/cbLTC.png",
-    "name": "Coinbase Wrapped LTC",
-    "symbol": "cbLTC"
-  },
-  {
-    "address": "0x29cC30f9D113B356Ce408667aa6433589CeCBDcA",
-    "chainId": 8453,
-    "decimals": 18,
-    "logoURI": "https://files.sablier.com/tokens/ELSA.png",
-    "name": "Elsa",
-    "symbol": "ELSA"
   }
 ]

--- a/token-list/evm/999.json
+++ b/token-list/evm/999.json
@@ -1,5 +1,13 @@
 [
   {
+    "address": "0x58538e6A46E07434d7E7375Bc268D3cb839C0133",
+    "chainId": 999,
+    "decimals": 18,
+    "logoURI": "https://files.sablier.com/tokens/ENA.png",
+    "name": "ENA",
+    "symbol": "ENA"
+  },
+  {
     "address": "0x03832767BDf9A8EF007449942125Ad605aCfADb8",
     "chainId": 999,
     "decimals": 18,
@@ -30,13 +38,5 @@
     "logoURI": "https://files.sablier.com/tokens/WHYPE.png",
     "name": "Wrapped HYPE",
     "symbol": "WHYPE"
-  },
-  {
-    "address": "0x58538e6A46E07434d7E7375Bc268D3cb839C0133",
-    "chainId": 999,
-    "decimals": 18,
-    "logoURI": "https://files.sablier.com/tokens/ENA.png",
-    "name": "ENA",
-    "symbol": "ENA"
   }
 ]

--- a/token-list/evm/999.json
+++ b/token-list/evm/999.json
@@ -16,20 +16,20 @@
     "symbol": "SWAP"
   },
   {
-    "address": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb",
-    "chainId": 999,
-    "decimals": 6,
-    "logoURI": "https://files.sablier.com/tokens/USDT.png",
-    "name": "USD₮0",
-    "symbol": "USD₮0"
-  },
-  {
     "address": "0xb88339CB7199b77E23DB6E890353E22632Ba630f",
     "chainId": 999,
     "decimals": 6,
     "logoURI": "https://files.sablier.com/tokens/USDC.png",
     "name": "USD Coin",
     "symbol": "USDC"
+  },
+  {
+    "address": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb",
+    "chainId": 999,
+    "decimals": 6,
+    "logoURI": "https://files.sablier.com/tokens/USDT.png",
+    "name": "USD₮0",
+    "symbol": "USD₮0"
   },
   {
     "address": "0x5555555555555555555555555555555555555555",

--- a/token-list/solana/devnet.json
+++ b/token-list/solana/devnet.json
@@ -1,15 +1,5 @@
 [
   {
-    "address": "6SNumpJmqb1CAKsxxiVqXxjTUXe1TxPbUi9jd7wG4a1P",
-    "chainId": 900000020,
-    "cluster": "devnet",
-    "decimals": 6,
-    "logoURI": "https://files.sablier.com/tokens/USDC.png",
-    "name": "USDC Dev",
-    "program": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-    "symbol": "USDCD"
-  },
-  {
     "address": "So11111111111111111111111111111111111111112",
     "chainId": 900000020,
     "cluster": "devnet",
@@ -18,5 +8,15 @@
     "name": "Wrapped SOL",
     "program": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
     "symbol": "SOL"
+  },
+  {
+    "address": "6SNumpJmqb1CAKsxxiVqXxjTUXe1TxPbUi9jd7wG4a1P",
+    "chainId": 900000020,
+    "cluster": "devnet",
+    "decimals": 6,
+    "logoURI": "https://files.sablier.com/tokens/USDC.png",
+    "name": "USDC Dev",
+    "program": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    "symbol": "USDCD"
   }
 ]

--- a/token-list/solana/mainnet-beta.json
+++ b/token-list/solana/mainnet-beta.json
@@ -1,5 +1,25 @@
 [
   {
+    "address": "2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv",
+    "chainId": 900000010,
+    "cluster": "mainnet-beta",
+    "decimals": 6,
+    "logoURI": "https://files.sablier.com/tokens/PENGU.png",
+    "name": "Pudgy Penguins",
+    "program": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    "symbol": "PENGU"
+  },
+  {
+    "address": "pSo1f9nQXWgXibFtKf7NWYxb5enAM4qfP6UJSiXRQfL",
+    "chainId": 900000010,
+    "cluster": "mainnet-beta",
+    "decimals": 9,
+    "logoURI": "https://files.sablier.com/tokens/PSOL.png",
+    "name": "Phantom Staked SOL",
+    "program": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    "symbol": "PSOL"
+  },
+  {
     "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
     "chainId": 900000010,
     "cluster": "mainnet-beta",
@@ -28,25 +48,5 @@
     "name": "Wrapped SOL",
     "program": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
     "symbol": "WSOL"
-  },
-  {
-    "address": "2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv",
-    "chainId": 900000010,
-    "cluster": "mainnet-beta",
-    "decimals": 6,
-    "logoURI": "https://files.sablier.com/tokens/PENGU.png",
-    "name": "Pudgy Penguins",
-    "program": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-    "symbol": "PENGU"
-  },
-  {
-    "address": "pSo1f9nQXWgXibFtKf7NWYxb5enAM4qfP6UJSiXRQfL",
-    "chainId": 900000010,
-    "cluster": "mainnet-beta",
-    "decimals": 9,
-    "logoURI": "https://files.sablier.com/tokens/PSOL.png",
-    "name": "Phantom Staked SOL",
-    "program": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-    "symbol": "PSOL"
   }
 ]


### PR DESCRIPTION
## Summary

Extends `scripts/token-list/sort-tokens.ts` to sort **source token files** (`token-list/evm/*.json`, `token-list/solana/*.json`) in addition to generated lists (`token-list/evm.json`, `token-list/solana.json`).

## Problem

Previously, `just sort-tokens` only sorted generated files, so source files could remain unsorted and create noisy, inconsistent diffs.

## Solution

- Add source-file sorting pass for `evm/` and `solana/` directories
- Keep generated-file sorting pass for `token-list/*.json`
- Use `localeCompare` consistently for symbol ordering (including Solana path)

## Validation

- Token JSON diffs in this PR are reorder-only (no semantic field changes)
- Sorting behavior now applies to both source and generated files

## Depends on

- https://github.com/sablier-labs/sablier-labs.github.io/pull/32
